### PR TITLE
Some proposals for improvement of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Learning Resource Metadata Initiative Development & Guidance
 
+The [LRMI specification](https://www.dublincore.org/specifications/lrmi/) is a collection of classes, properties and concept schemes for markup and description of educational resources. This vocabulary is designed to be used alongside other resource description vocabularies such as those provided by DCMI, [Schema.org](https://schema.org) and other standards. A significant part of the LRMI specification is mirrored under the [schema.org/LearningResource](https://schema.org/LearningResource) class.
+
 This repository provides in-development and informative resources about [LRMI](https://www.dublincore.org/about/lrmi/), including:
 * [LRMI Terms](lrmi_terms/): development versions of RDF definitions of LRMI Terms in Turtle;
 * [LRMI Vocabs](lrmi_vocabs): development versions of RDF definitions of concept schemes relevant to LRMI terms;
@@ -7,10 +9,8 @@ This repository provides in-development and informative resources about [LRMI](h
 
 For the stable, normative versions of the terms and concept schemes, see [LRMI Specifications](https://www.dublincore.org/specifications/lrmi/) on the DCMI website.
 
-To contribute to the development of LRMI please join the [DCMI LRMI Task Group](https://www.dublincore.org/groups/lrmi-task-group/)
+## Contribute
 
-## About LRMI
-The [LRMI specification](https://www.dublincore.org/specifications/lrmi/) is a collection of classes, properties and concept schemes for markup and description of educational resources. This vocabulary is designed to be used alongside other resource description vocabularies such as those provided by DCMI, [Schema.org](https://schema.org) and other standards. A significant part of the LRMI specification is mirrored under the [schema.org/LearningResource](https://schema.org/LearningResource) class.
+The specification is curated by the DCMI [LRMI Task Group](https://www.dublincore.org/groups/lrmi-task-group/). We encourage you to suggest improvements for LRMI by opening an [issue](https://github.com/dcmi/lrmi/issues/new/choose) or making a pull request.
 
-## LRMI Development
-The specification is curated by the DCMI [LRMI Task Group](https://www.dublincore.org/groups/lrmi-task-group/), mainly through monthly calls at 07:00 (Pacific Time) on the first Tuesday of the month. For information about these calls, including agenda and further discussion, join the [DC-LRMI Task Group mail list](https://www.jiscmail.ac.uk/cgi-bin/webadmin?A0=DC-LRMI).
+To participate in the LRMI Task Group, we invite you to join our monthly calls at [14:00 UTC](https://www.timeanddate.com/worldclock/converter.html?iso=20210601T140000&p1=224&p2=220&p3=64&p4=179&p5=304&p6=37&p7=5197) on the first Tuesday of the month. For information about these calls, including agenda and further discussion, join the [DC-LRMI Task Group mail list](https://www.jiscmail.ac.uk/cgi-bin/webadmin?A0=DC-LRMI).


### PR DESCRIPTION
Thanks, @philbarker, for having started the improvement of the [README.md](https://github.com/dcmi/lrmi/blob/main/README.md). I just took a look at it and here suggest some improvements in this PR:

-  Start with the "About" part.
- Re. "To contribute to the development of LRMI please join the DCMI LRMI Task Group": As there is no guidance on _how_ to join the TG on the groups homepage, I removed the phrase. (We should add a guidance on how to join the group on the TG page, though.)
-  Rename the "LRMI development" paragraph to "Contribute" to encourage involvement and add a link to the new issue page as well as encourage PRs.